### PR TITLE
add missing required cupertino import with recent version of flutter …

### DIFF
--- a/lib/navigation/src/ui/sint_root.dart
+++ b/lib/navigation/src/ui/sint_root.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 


### PR DESCRIPTION
…due to flutter refactoring (fixing error: sint_root.dart:184:12: Error: 'CupertinoPageTransitionsBuilder' isn't a type.)
